### PR TITLE
Update Parchment to 1.21

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,8 +5,8 @@ org.gradle.debug=false
 
 #read more on this at https://github.com/neoforged/NeoGradle/blob/NG_7.0/README.md#apply-parchment-mappings
 # you can also find the latest versions at: https://parchmentmc.org/docs/getting-started
-neogradle.subsystems.parchment.minecraftVersion=1.20.6
-neogradle.subsystems.parchment.mappingsVersion=2024.05.01
+neogradle.subsystems.parchment.minecraftVersion=1.21
+neogradle.subsystems.parchment.mappingsVersion=2024.07.07
 # Environment Properties
 # You can find the latest versions here: https://projects.neoforged.net/neoforged/neoforge
 # The Minecraft version must agree with the Neo version to get a valid artifact


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/23554274-ac2b-4909-bc41-a2ea19c64469)

ParchmentMC's website shows that 1.21 is out, so I updated it to 1.21